### PR TITLE
Added a method to split Japanese

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -3,9 +3,11 @@ const cors = require("cors");
 const app = express();
 
 const { splitChineseTextRow } = require("./split-chinese");
+const { splitJapaneseTextRow } = require("./split-japanese");
 
 const splitFunctions = {
   chinese: splitChineseTextRow,
+  japanese: splitJapaneseTextRow,
 };
 
 // Enable CORS for all routes

--- a/api/split-japanese.js
+++ b/api/split-japanese.js
@@ -1,0 +1,82 @@
+const cheerio = require("cheerio");
+
+// In memory cache
+const cache = {};
+
+const splitJapaneseTextRow = async (text) => {
+
+  if (cache[text]) {
+    console.log("returning from cache");
+    return cache[text];
+  }
+
+  const encodedText = encodeURIComponent(text);
+  const response = await fetch(`https://ichi.moe/cl/qr/?q=${encodedText}&r=htr`, {
+    method: "GET",
+  });
+
+  if (!response.ok) {
+    throw new Error(`HTTP error! status: ${response.status}`);
+  }
+
+  const data = await response.text();
+
+  // Extract words from the HTML response using cheerio
+
+  const $ = cheerio.load(data);
+
+  const wordMatches = $(".gloss-content")
+  if (wordMatches.length === 0) {
+    console.log(data);
+    throw new Error("BadRequest: No annotated text found");
+  }
+
+  const words = wordMatches
+    .map((_, el) => extractWordFromBox($, el))
+    .toArray()
+    .filter(Boolean);
+
+  // Create an array that includes both words and punctuation
+  let remainingText = text;
+  const allSegments = [];
+
+  words.forEach((word) => {
+    const wordIndex = remainingText.indexOf(word);
+    if (wordIndex > 0) {
+      // Add any characters before the word (punctuation/spaces)
+      allSegments.push(remainingText.substring(0, wordIndex));
+    }
+    // Add the word itself
+    allSegments.push(word);
+    // Update remaining text to continue search
+    remainingText = remainingText.substring(wordIndex + word.length);
+  });
+
+  // Add any remaining characters at the end
+  if (remainingText.length > 0) {
+    allSegments.push(remainingText);
+  }
+
+  const result = {
+    words: words,
+    segmented: allSegments.join(" "),
+    text,
+  };
+
+  cache[text] = result;
+
+  return result;
+};
+
+const extractWordFromBox = ($, box) => {
+  // The text here might look like
+  // "1. ある" or "猫 【ねこ】" so we need to remove those things and leave only the japanese text
+  return $('.alternatives dt', box).first().text()
+    .replace(/【.*?】/g, '') // Remove 【...】
+    .replace(/^\d+\.\s*/, '') // Remove leading numbers and dots
+    .trim();
+};
+
+module.exports = {
+  splitJapaneseTextRow,
+};

--- a/readme.md
+++ b/readme.md
@@ -1,10 +1,10 @@
-# Split Chinese
+# Split Chinese & Japanese
 
-Split Chinese into words.
+Split Chinese or Japanese text into words.
 
-This API is a tiny wrapper around [MandarinSpot](https://mandarinspot.com/annotate).
+This API is a tiny wrapper around [MandarinSpot](https://mandarinspot.com/annotate) and [ichi.moe](https://ichi.moe) sites to allow getting split words in JSON.
 
-Please do not abuse this API or MandarinSpot.
+Please do not abuse this API, MandarinSpot or ichi.moe.
 
 
 Please also note that there is an official JS library you can use client side [https://mandarinspot.com/api](https://mandarinspot.com/api).
@@ -22,6 +22,21 @@ let response = await fetch("http://localhost:3000/?text=你好吗");
 let data = await response.json();
 console.log(data);
 ```
+
+## Language support
+
+- Chinese
+- Japanese
+
+Pass in a `lang` query param to specify the language.
+
+For example:
+
+`http://localhost:3000/?text=你好吗&lang=chinese` for Chinese (default if not specified)
+
+or
+
+`http://localhost:3000/?text=私は猫である&lang=japanese` for Japanese
 
 
 ## Usage


### PR DESCRIPTION
# Overview

Adds Japanese support as well by using `ichi.moe`

![image](https://github.com/user-attachments/assets/e705508b-4ad5-4449-9f8b-a39ca61b7c6a)
